### PR TITLE
set_node_engine: explicit bin call in NodeSession$New

### DIFF
--- a/R/knitr.R
+++ b/R/knitr.R
@@ -6,7 +6,7 @@ set_node_engine <- function(
   bin = find_node()
 ){
   knitr::opts_chunk$set(
-    node = bubble::NodeSession$new()
+    node = bubble::NodeSession$new(bin = bin)
   )
   knitr::knit_engines$set(node = function(
     options


### PR DESCRIPTION
In case you have to explicit nodejs path in `set_node_engine` if `node_find` cannot find the path.